### PR TITLE
Implement stable blank node ordering

### DIFF
--- a/cool-rdf-formatter/src/main/java/cool/rdf/formatter/BlankNodeComparator.java
+++ b/cool-rdf-formatter/src/main/java/cool/rdf/formatter/BlankNodeComparator.java
@@ -41,6 +41,7 @@ final class BlankNodeComparator implements Comparator<Resource> {
    private final Model model;
    private final PrefixMapping prefixMapping;
    private final BlankNodeMetadata blankNodeMetadata;
+   private final boolean preserveBlankNodeLabelsAndOrdering;
    private final Map<Resource, String[]> keys = new LinkedHashMap<>( CACHE_SIZE, 0.75f, true ) {
       @Override
       protected boolean removeEldestEntry( final Map.Entry<Resource, String[]> eldest ) {
@@ -49,10 +50,11 @@ final class BlankNodeComparator implements Comparator<Resource> {
    };
 
    BlankNodeComparator( final Model model, final PrefixMapping prefixMapping,
-         final BlankNodeMetadata blankNodeMetadata ) {
+         final BlankNodeMetadata blankNodeMetadata, final boolean preserveBlankNodeLabelsAndOrdering ) {
       this.model = model;
       this.prefixMapping = prefixMapping;
       this.blankNodeMetadata = blankNodeMetadata;
+      this.preserveBlankNodeLabelsAndOrdering = preserveBlankNodeLabelsAndOrdering;
    }
 
    @Override
@@ -60,11 +62,13 @@ final class BlankNodeComparator implements Comparator<Resource> {
       if ( left.equals( right ) ) {
          return 0;
       }
-      final Long leftOrder = blankNodeMetadata.getOrder( left.asNode() );
-      final Long rightOrder = blankNodeMetadata.getOrder( right.asNode() );
-      if ( leftOrder != null || rightOrder != null ) {
-         return Optional.ofNullable( leftOrder ).orElse( Long.MAX_VALUE )
-               .compareTo( Optional.ofNullable( rightOrder ).orElse( Long.MAX_VALUE ) );
+      if ( preserveBlankNodeLabelsAndOrdering ) {
+         final Long leftOrder = blankNodeMetadata.getOrder( left.asNode() );
+         final Long rightOrder = blankNodeMetadata.getOrder( right.asNode() );
+         if ( leftOrder != null || rightOrder != null ) {
+            return Optional.ofNullable( leftOrder ).orElse( Long.MAX_VALUE )
+                  .compareTo( Optional.ofNullable( rightOrder ).orElse( Long.MAX_VALUE ) );
+         }
       }
       for ( int depth = 1; depth <= MAX_DEPTH; depth++ ) {
          final int result = key( left, depth ).compareTo( key( right, depth ) );

--- a/cool-rdf-formatter/src/main/java/cool/rdf/formatter/BlankNodeComparator.java
+++ b/cool-rdf-formatter/src/main/java/cool/rdf/formatter/BlankNodeComparator.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Cool RDF project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cool.rdf.formatter;
+
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.jena.rdf.model.Literal;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.shared.PrefixMapping;
+
+import cool.rdf.formatter.blanknode.BlankNodeMetadata;
+
+final class BlankNodeComparator implements Comparator<Resource> {
+
+   private static final int MAX_DEPTH = 3;
+   private static final int CACHE_SIZE = 100;
+
+   private final Model model;
+   private final PrefixMapping prefixMapping;
+   private final BlankNodeMetadata blankNodeMetadata;
+   private final Map<Resource, String[]> keys = new LinkedHashMap<>( CACHE_SIZE, 0.75f, true ) {
+      @Override
+      protected boolean removeEldestEntry( final Map.Entry<Resource, String[]> eldest ) {
+         return size() > CACHE_SIZE;
+      }
+   };
+
+   BlankNodeComparator( final Model model, final PrefixMapping prefixMapping,
+         final BlankNodeMetadata blankNodeMetadata ) {
+      this.model = model;
+      this.prefixMapping = prefixMapping;
+      this.blankNodeMetadata = blankNodeMetadata;
+   }
+
+   @Override
+   public int compare( final Resource left, final Resource right ) {
+      if ( left.equals( right ) ) {
+         return 0;
+      }
+      final Long leftOrder = blankNodeMetadata.getOrder( left.asNode() );
+      final Long rightOrder = blankNodeMetadata.getOrder( right.asNode() );
+      if ( leftOrder != null || rightOrder != null ) {
+         return Optional.ofNullable( leftOrder ).orElse( Long.MAX_VALUE )
+               .compareTo( Optional.ofNullable( rightOrder ).orElse( Long.MAX_VALUE ) );
+      }
+      for ( int depth = 1; depth <= MAX_DEPTH; depth++ ) {
+         final int result = key( left, depth ).compareTo( key( right, depth ) );
+         if ( result != 0 ) {
+            return result;
+         }
+      }
+      return 0;
+   }
+
+   private String key( final Resource resource, final int depth ) {
+      final String[] keysByDepth = keys.computeIfAbsent( resource, ignored -> new String[MAX_DEPTH] );
+      String key = keysByDepth[depth - 1];
+      if ( key == null ) {
+         key = blankNodeKey( resource, depth, new HashSet<>() );
+         keysByDepth[depth - 1] = key;
+      }
+      return key;
+   }
+
+   private String rdfNodeKey( final RDFNode node, final int depth, final Set<Resource> visitedBlankNodes ) {
+      if ( node.isURIResource() ) {
+         return "0U:" + prefixMapping.shortForm( node.asResource().getURI() );
+      }
+      if ( node.isLiteral() ) {
+         final Literal literal = node.asLiteral();
+         return "2L:" + literal.getDatatypeURI() + "|" + literal.getLanguage() + "|" + literal.getLexicalForm();
+      }
+      if ( node.isAnon() ) {
+         return blankNodeKey( node.asResource(), depth, visitedBlankNodes );
+      }
+      return "3N:";
+   }
+
+   private String blankNodeKey( final Resource resource, final int depth,
+         final Set<Resource> visitedBlankNodes ) {
+      if ( depth <= 0 ) {
+         return "1B";
+      }
+      if ( visitedBlankNodes.contains( resource ) ) {
+         return "1BCYCLE";
+      }
+
+      final Set<Resource> nextVisitedBlankNodes = new HashSet<>( visitedBlankNodes );
+      nextVisitedBlankNodes.add( resource );
+      final List<String> outgoing = model.listStatements( resource, null, (RDFNode) null )
+            .toList()
+            .stream()
+            .map( statement -> "S:" + predicateKey( statement.getPredicate() ) + "="
+                  + rdfNodeKey( statement.getObject(), depth - 1, nextVisitedBlankNodes ) )
+            .sorted()
+            .toList();
+      final List<String> incoming = model.listStatements( null, null, resource )
+            .toList()
+            .stream()
+            .map( statement -> "O:" + rdfNodeKey( statement.getSubject(), depth - 1,
+                  nextVisitedBlankNodes ) + "=" + predicateKey( statement.getPredicate() ) )
+            .sorted()
+            .toList();
+      return "1B[" + String.join( ";", outgoing ) + "][" + String.join( ";", incoming ) + "]";
+   }
+
+   private String predicateKey( final Property predicate ) {
+      return prefixMapping.shortForm( predicate.getURI() );
+   }
+}

--- a/cool-rdf-formatter/src/main/java/cool/rdf/formatter/FormattingStyle.java
+++ b/cool-rdf-formatter/src/main/java/cool/rdf/formatter/FormattingStyle.java
@@ -78,6 +78,7 @@ public record FormattingStyle(
       @RecordBuilder.Initializer( "DEFAULT_MAX_LINE_LENGTH" ) int maxLineLength,
       @RecordBuilder.Initializer( "DEFAULT_TRIM_TRAILING_WHITESPACE" ) boolean trimTrailingWhitespace,
       @RecordBuilder.Initializer( "DEFAULT_KEEP_UNUSED_PREFIXES" ) boolean keepUnusedPrefixes,
+      @RecordBuilder.Initializer( "DEFAULT_PRESERVE_BLANK_NODE_LABELS_AND_ORDERING" ) boolean preserveBlankNodeLabelsAndOrdering,
       @RecordBuilder.Initializer( "DEFAULT_PREFIX_ORDER" ) List<String> prefixOrder,
       @RecordBuilder.Initializer( "DEFAULT_SUBJECT_ORDER" ) List<Resource> subjectOrder,
       @RecordBuilder.Initializer( "DEFAULT_PREDICATE_ORDER" ) List<Property> predicateOrder,
@@ -130,6 +131,7 @@ public record FormattingStyle(
    public static final int DEFAULT_MAX_LINE_LENGTH = 100;
    public static final boolean DEFAULT_TRIM_TRAILING_WHITESPACE = true;
    public static final boolean DEFAULT_KEEP_UNUSED_PREFIXES = false;
+   public static final boolean DEFAULT_PRESERVE_BLANK_NODE_LABELS_AND_ORDERING = true;
    public static final List<String> DEFAULT_PREFIX_ORDER = List.of(
          "rdf",
          "rdfs",

--- a/cool-rdf-formatter/src/main/java/cool/rdf/formatter/TurtleFormatter.java
+++ b/cool-rdf-formatter/src/main/java/cool/rdf/formatter/TurtleFormatter.java
@@ -59,6 +59,7 @@ import org.apache.jena.vocabulary.XSD;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import cool.rdf.core.model.RdfModel;
 import cool.rdf.core.model.RdfPrefix;
 import cool.rdf.formatter.blanknode.BlankNodeMetadata;
 import cool.rdf.formatter.blanknode.BlankNodeOrderAwareTurtleParser;
@@ -173,13 +174,21 @@ public class TurtleFormatter implements Function<Model, String>, BiConsumer<Mode
       if ( style.charset() == FormattingStyle.Charset.UTF_8_BOM ) {
          writeByteOrderMark( outputStream );
       }
-      final BlankNodeOrderAwareTurtleParser.ParseResult result = BlankNodeOrderAwareTurtleParser.parseModel( content );
-      final Model model = result.model();
-      final BlankNodeMetadata blankNodeMetadata = result.blankNodeMetadata();
+      if ( style.preserveBlankNodeLabelsAndOrdering() ) {
+         final BlankNodeOrderAwareTurtleParser.ParseResult result = BlankNodeOrderAwareTurtleParser.parseModel( content );
+         final Model model = result.model();
+         final BlankNodeMetadata blankNodeMetadata = result.blankNodeMetadata();
+         final PrefixMapping prefixMapping = buildPrefixMapping( model );
+         final RDFNodeComparatorFactory rdfNodeComparatorFactory = new RDFNodeComparatorFactory( prefixMapping,
+               blankNodeMetadata );
+         doFormat( model, prefixMapping, rdfNodeComparatorFactory, blankNodeMetadata, outputStream );
+         return;
+      }
+
+      final Model model = RdfModel.fromTurtle( content );
       final PrefixMapping prefixMapping = buildPrefixMapping( model );
-      final RDFNodeComparatorFactory rdfNodeComparatorFactory = new RDFNodeComparatorFactory( prefixMapping,
-            blankNodeMetadata );
-      doFormat( model, prefixMapping, rdfNodeComparatorFactory, blankNodeMetadata, outputStream );
+      final RDFNodeComparatorFactory rdfNodeComparatorFactory = new RDFNodeComparatorFactory( prefixMapping );
+      doFormat( model, prefixMapping, rdfNodeComparatorFactory, BlankNodeMetadata.gotNothing(), outputStream );
    }
 
    private void writeByteOrderMark( final OutputStream outputStream ) {
@@ -224,7 +233,8 @@ public class TurtleFormatter implements Function<Model, String>, BiConsumer<Mode
             .prefixMapping( prefixMapping )
             .rdfNodeComparatorFactory( rdfNodeComparatorFactory )
             .blankNodeMetadata( blankNodeMetadata )
-            .blankNodeComparator( new BlankNodeComparator( model, prefixMapping, blankNodeMetadata ) )
+            .blankNodeComparator( new BlankNodeComparator( model, prefixMapping, blankNodeMetadata,
+                  style.preserveBlankNodeLabelsAndOrdering() ) )
             .build();
       final State initialState = buildInitialState( context, outputStream );
       final State prefixesWritten = writePrefixes( initialState );

--- a/cool-rdf-formatter/src/main/java/cool/rdf/formatter/TurtleFormatter.java
+++ b/cool-rdf-formatter/src/main/java/cool/rdf/formatter/TurtleFormatter.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -223,10 +224,11 @@ public class TurtleFormatter implements Function<Model, String>, BiConsumer<Mode
             .prefixMapping( prefixMapping )
             .rdfNodeComparatorFactory( rdfNodeComparatorFactory )
             .blankNodeMetadata( blankNodeMetadata )
+            .blankNodeComparator( new BlankNodeComparator( model, prefixMapping, blankNodeMetadata ) )
             .build();
       final State initialState = buildInitialState( context, outputStream );
       final State prefixesWritten = writePrefixes( initialState );
-      final List<Statement> statements = determineStatements( model, rdfNodeComparatorFactory );
+      final List<Statement> statements = determineStatements( context );
       final State namedResourcesWritten = writeNamedResources( prefixesWritten, statements );
       final State allResourcesWritten = writeAnonymousResources( namedResourcesWritten );
       final State finalState = style.insertFinalNewline() ? allResourcesWritten.newLine() : allResourcesWritten;
@@ -239,7 +241,7 @@ public class TurtleFormatter implements Function<Model, String>, BiConsumer<Mode
       final List<Resource> sortedAnonymousIdentifiedResources = state.identifiedAnonymousResources
             .keySet()
             .stream()
-            .sorted( state.context().rdfNodeComparatorFactory().comparator() )
+            .sorted( rdfNodeComparator( state ) )
             .toList();
       for ( final Resource resource : sortedAnonymousIdentifiedResources ) {
          if ( !resource.listProperties().hasNext() ) {
@@ -268,18 +270,19 @@ public class TurtleFormatter implements Function<Model, String>, BiConsumer<Mode
       return currentState;
    }
 
-   private List<Statement> determineStatements( final Model model,
-         final RDFNodeComparatorFactory rdfNodeComparatorFactory ) {
+   private List<Statement> determineStatements( final Context context ) {
+      final Model model = context.model();
+      final Comparator<RDFNode> rdfNodeOrder = rdfNodeComparator( context );
       final Stream<Statement> wellKnownSubjects = style.subjectOrder().stream().flatMap( subjectType -> statements( model, RDF.type,
             subjectType )
                   .stream()
-                  .sorted( Comparator.comparing( Statement::getSubject, rdfNodeComparatorFactory.comparator() ) ) );
+                  .sorted( Comparator.comparing( Statement::getSubject, rdfNodeOrder ) ) );
 
       final Stream<Statement> otherSubjects = statements( model ).stream()
             .filter( statement -> !( statement.getPredicate().equals( RDF.type )
                   && statement.getObject().isResource()
                   && style.subjectOrder().contains( statement.getObject().asResource() ) ) )
-            .sorted( Comparator.comparing( Statement::getSubject, rdfNodeComparatorFactory.comparator() ) );
+            .sorted( Comparator.comparing( Statement::getSubject, rdfNodeOrder ) );
 
       return Stream.concat( wellKnownSubjects, otherSubjects )
             .filter( statement -> !( statement.getSubject().isAnon()
@@ -291,7 +294,9 @@ public class TurtleFormatter implements Function<Model, String>, BiConsumer<Mode
       State currentState = new State( context, outputStream );
       int i = 0;
       final Set<String> blankNodeLabelsInInput = context.blankNodeMetadata().getAllBlankNodeLabels();
-      for ( final Resource r : anonymousResourcesThatNeedAnId( context.model(), currentState ) ) {
+      for ( final Resource r : anonymousResourcesThatNeedAnId( context.model(), currentState ).stream()
+            .sorted( rdfNodeComparator( currentState ) )
+            .toList() ) {
          // use original label if present
          String s = context.blankNodeMetadata().getLabel( r.asNode() );
          if ( s == null ) {
@@ -312,9 +317,9 @@ public class TurtleFormatter implements Function<Model, String>, BiConsumer<Mode
     *
     * @param model the input model
     * @param currentState the state
-    * @return the set of anonymous resources that are referred to more than once
+    * @return the ordered list of anonymous resources that are referred to more than once
     */
-   private Set<Resource> anonymousResourcesThatNeedAnId( final Model model, final State currentState ) {
+   private List<Resource> anonymousResourcesThatNeedAnId( final Model model, final State currentState ) {
       final Set<Resource> identifiedResources = new HashSet<>( currentState.identifiedAnonymousResources.keySet() );
       // needed for cycle detection
       final Set<Resource> candidates = model.listObjects().toList().stream()
@@ -325,11 +330,12 @@ public class TurtleFormatter implements Function<Model, String>, BiConsumer<Mode
       final List<Resource> candidatesInOrder = Stream.concat(
             currentState.context().blankNodeMetadata().getLabeledBlankNodes()
                   .stream()
-                  .sorted( currentState.context().rdfNodeComparatorFactory().comparator() ),
+                  .sorted( rdfNodeComparator( currentState ) ),
             candidates
                   .stream()
-                  .sorted( currentState.context().rdfNodeComparatorFactory().comparator() ) )
+                  .sorted( rdfNodeComparator( currentState ) ) )
             .toList();
+      final List<Resource> newlyIdentifiedResources = new ArrayList<>();
       for ( final Resource candidate : candidatesInOrder ) {
          if ( identifiedResources.contains( candidate ) ) {
             continue;
@@ -337,10 +343,10 @@ public class TurtleFormatter implements Function<Model, String>, BiConsumer<Mode
          if ( statements( model, null, candidate ).size() > 1 || hasBlankNodeCycle( model, candidate,
                identifiedResources ) ) {
             identifiedResources.add( candidate );
+            newlyIdentifiedResources.add( candidate );
          }
       }
-      identifiedResources.removeAll( currentState.identifiedAnonymousResources.keySet() );
-      return identifiedResources;
+      return newlyIdentifiedResources;
    }
 
    private boolean hasBlankNodeCycle( final Model model, final Resource start,
@@ -821,8 +827,9 @@ public class TurtleFormatter implements Function<Model, String>, BiConsumer<Mode
 
       int index = 0;
       State currentState = predicateWrittenOnce;
-      for ( final RDFNode object : objects.stream().sorted( objectOrder.thenComparing(
-            state.context().rdfNodeComparatorFactory().comparator() ) ).toList() ) {
+      for ( final RDFNode object : objects.stream()
+            .sorted( objectComparator( state ) )
+            .toList() ) {
          final boolean lastObject = index == objects.size() - 1;
          final State predicateWritten = useComma ? currentState : writeProperty( predicate, currentState );
 
@@ -864,6 +871,31 @@ public class TurtleFormatter implements Function<Model, String>, BiConsumer<Mode
          index++;
       }
       return currentState;
+   }
+
+   private Comparator<RDFNode> objectComparator( final State state ) {
+      final Comparator<RDFNode> rdfNodeOrder = rdfNodeComparator( state );
+      final Comparator<RDFNode> nonBlankObjectOrder = objectOrder.thenComparing( rdfNodeOrder );
+      return ( left, right ) -> left.isAnon() && right.isAnon()
+            ? rdfNodeOrder.compare( left, right )
+            : nonBlankObjectOrder.compare( left, right );
+   }
+
+   private Comparator<RDFNode> rdfNodeComparator( final State state ) {
+      return rdfNodeComparator( state.context() );
+   }
+
+   private Comparator<RDFNode> rdfNodeComparator( final Context context ) {
+      final Comparator<RDFNode> fallback = context.rdfNodeComparatorFactory().comparator();
+      return ( left, right ) -> {
+         if ( left.equals( right ) ) {
+            return 0;
+         }
+         if ( left.isAnon() && right.isAnon() ) {
+            return context.blankNodeComparator().compare( left.asResource(), right.asResource() );
+         }
+         return fallback.compare( left, right );
+      };
    }
 
    class NodeFormatterSink implements AWriter {
@@ -929,7 +961,8 @@ public class TurtleFormatter implements Function<Model, String>, BiConsumer<Mode
          Comparator<Property> predicateOrder,
          PrefixMapping prefixMapping,
          RDFNodeComparatorFactory rdfNodeComparatorFactory,
-         BlankNodeMetadata blankNodeMetadata
+         BlankNodeMetadata blankNodeMetadata,
+         BlankNodeComparator blankNodeComparator
    ) {}
 
    @RecordBuilder

--- a/cool-rdf-formatter/src/test/java/cool/rdf/formatter/TurtleFormatterTest.java
+++ b/cool-rdf-formatter/src/test/java/cool/rdf/formatter/TurtleFormatterTest.java
@@ -796,12 +796,110 @@ public class TurtleFormatterTest {
    @ParameterizedTest
    @MethodSource
    void testConsistentBlankNodeOrdering( final String content ) {
-      final FormattingStyle style = FormattingStyle.DEFAULT;
+      final FormattingStyle style = preserveBlankNodeLabelsAndOrderingStyle();
       final TurtleFormatter formatter = new TurtleFormatter( style );
       for ( int i = 0; i < 1; i++ ) {
          final String result = formatter.applyToContent( content );
          assertThat( result.trim() ).isEqualTo( content.trim() );
       }
+   }
+
+   @Test
+   void testBlankNodeLabelsAndOrderingAreNotPreservedWhenDisabled() {
+      final String content = """
+         @prefix ex: <http://example.com/ns#> .
+
+         ex:aThing ex:has [
+             ex:value "z" ;
+           ] ;
+           ex:has [
+             ex:value "a" ;
+           ] .
+         """;
+      final String expected = """
+         @prefix ex: <http://example.com/ns#> .
+
+         ex:aThing ex:has [
+             ex:value "a" ;
+           ] ;
+           ex:has [
+             ex:value "z" ;
+           ] .
+         """;
+      final FormattingStyle style = FormattingStyle.builder()
+            .knownPrefixes( Set.of() )
+            .preserveBlankNodeLabelsAndOrdering( false )
+            .build();
+      assertThat( style.preserveBlankNodeLabelsAndOrdering() ).isFalse();
+      final TurtleFormatter formatter = new TurtleFormatter( style );
+
+      final String result = formatter.applyToContent( content );
+
+      assertThat( result.trim() ).isEqualTo( expected.trim() );
+   }
+
+   @Test
+   void testBlankNodeLabelsAndOrderingArePreservedByDefault() {
+      final String content = """
+         @prefix ex: <http://example.com/ns#> .
+
+         ex:aThing ex:has [
+             ex:value "z" ;
+           ] ;
+           ex:has [
+             ex:value "a" ;
+           ] .
+         """;
+      final FormattingStyle style = FormattingStyle.builder()
+            .knownPrefixes( Set.of() )
+            .build();
+      assertThat( style.preserveBlankNodeLabelsAndOrdering() ).isTrue();
+      final TurtleFormatter formatter = new TurtleFormatter( style );
+
+      final String result = formatter.applyToContent( content );
+
+      assertThat( result.trim() ).isEqualTo( content.trim() );
+   }
+
+   @Test
+   void testBlankNodeLabelsAreNotPreservedWhenDisabled() {
+      final String content = """
+         @prefix ex: <http://example.com/ns#> .
+
+         ex:left ex:has _:sourceLabel .
+         ex:right ex:has _:sourceLabel .
+         _:sourceLabel ex:value "a" .
+         """;
+      final FormattingStyle style = FormattingStyle.builder()
+            .knownPrefixes( Set.of() )
+            .preserveBlankNodeLabelsAndOrdering( false )
+            .build();
+      assertThat( style.preserveBlankNodeLabelsAndOrdering() ).isFalse();
+      final TurtleFormatter formatter = new TurtleFormatter( style );
+
+      final String result = formatter.applyToContent( content );
+
+      assertThat( result ).doesNotContain( "_:sourceLabel" );
+   }
+
+   @Test
+   void testBlankNodeLabelsCanBePreserved() {
+      final String content = """
+         @prefix ex: <http://example.com/ns#> .
+
+         ex:left ex:has _:sourceLabel .
+         ex:right ex:has _:sourceLabel .
+         _:sourceLabel ex:value "a" .
+         """;
+      final FormattingStyle style = FormattingStyle.builder()
+            .knownPrefixes( Set.of() )
+            .preserveBlankNodeLabelsAndOrdering( true )
+            .build();
+      final TurtleFormatter formatter = new TurtleFormatter( style );
+
+      final String result = formatter.applyToContent( content );
+
+      assertThat( result ).contains( "_:sourceLabel" );
    }
 
    static Stream<Arguments> testConsistentBlankNodeOrdering() {
@@ -883,7 +981,7 @@ public class TurtleFormatterTest {
          _:gen0 ex:has [
              ex:has _:gen0 ;
            ] .""";
-      final FormattingStyle style = FormattingStyle.DEFAULT;
+      final FormattingStyle style = preserveBlankNodeLabelsAndOrderingStyle();
       final TurtleFormatter formatter = new TurtleFormatter( style );
       for ( int i = 0; i < 20; i++ ) {
          final String result = formatter.applyToContent( content );
@@ -906,7 +1004,7 @@ public class TurtleFormatterTest {
          _:blank1 ex:has [
              ex:has _:blank1 ;
            ] .""";
-      final FormattingStyle style = FormattingStyle.DEFAULT;
+      final FormattingStyle style = preserveBlankNodeLabelsAndOrderingStyle();
       final TurtleFormatter formatter = new TurtleFormatter( style );
       for ( int i = 0; i < 20; i++ ) {
          final String result = formatter.applyToContent( content );
@@ -929,7 +1027,7 @@ public class TurtleFormatterTest {
          ex:A ex:has [
              ex:has ex:A ;
            ] .""";
-      final FormattingStyle style = FormattingStyle.DEFAULT;
+      final FormattingStyle style = preserveBlankNodeLabelsAndOrderingStyle();
       final TurtleFormatter formatter = new TurtleFormatter( style );
       for ( int i = 0; i < 20; i++ ) {
          final String result = formatter.applyToContent( content );
@@ -958,7 +1056,7 @@ public class TurtleFormatterTest {
                ] ;
              ] ;
            ] .""";
-      final FormattingStyle style = FormattingStyle.DEFAULT;
+      final FormattingStyle style = preserveBlankNodeLabelsAndOrderingStyle();
       final TurtleFormatter formatter = new TurtleFormatter( style );
       for ( int i = 0; i < 20; i++ ) {
          final String result = formatter.applyToContent( content );
@@ -984,7 +1082,7 @@ public class TurtleFormatterTest {
                ex:has ex:A ;
              ] ;
            ] .""";
-      final FormattingStyle style = FormattingStyle.DEFAULT;
+      final FormattingStyle style = preserveBlankNodeLabelsAndOrderingStyle();
       final TurtleFormatter formatter = new TurtleFormatter( style );
       final String result = formatter.applyToContent( content );
       assertThat( result.trim() ).isEqualTo( expected );
@@ -1011,7 +1109,7 @@ public class TurtleFormatterTest {
          ex:B ex:has [
              ex:has ex:A ;
            ] .""";
-      final FormattingStyle style = FormattingStyle.DEFAULT;
+      final FormattingStyle style = preserveBlankNodeLabelsAndOrderingStyle();
       final TurtleFormatter formatter = new TurtleFormatter( style );
       final String result = formatter.applyToContent( content );
       assertThat( result.trim() ).isEqualTo( expected );
@@ -1034,7 +1132,7 @@ public class TurtleFormatterTest {
            ] ;
            :foo _:b3 ;
          ] .""";
-      final FormattingStyle style = FormattingStyle.DEFAULT;
+      final FormattingStyle style = preserveBlankNodeLabelsAndOrderingStyle();
       final TurtleFormatter formatter = new TurtleFormatter( style );
       for ( int i = 0; i < 20; i++ ) {
          final String result = formatter.applyToContent( content );
@@ -1064,7 +1162,7 @@ public class TurtleFormatterTest {
            ] ;
            :foo _:b3 ;
          ] .""";
-      final FormattingStyle style = FormattingStyle.DEFAULT;
+      final FormattingStyle style = preserveBlankNodeLabelsAndOrderingStyle();
       final TurtleFormatter formatter = new TurtleFormatter( style );
       for ( int i = 0; i < 20; i++ ) {
          final String result = formatter.applyToContent( content );
@@ -1374,6 +1472,12 @@ public class TurtleFormatterTest {
       final TurtleFormatter formatter = new TurtleFormatter( style );
       final String result = formatter.applyToContent( content );
       assertThat( result.trim() ).isEqualTo( expected );
+   }
+
+   private FormattingStyle preserveBlankNodeLabelsAndOrderingStyle() {
+      return FormattingStyle.builder()
+            .preserveBlankNodeLabelsAndOrdering( true )
+            .build();
    }
 
    private Model inMemorySiblingBlankNodeModel( final boolean allocateSomethingElseFirst ) {

--- a/cool-rdf-formatter/src/test/java/cool/rdf/formatter/TurtleFormatterTest.java
+++ b/cool-rdf-formatter/src/test/java/cool/rdf/formatter/TurtleFormatterTest.java
@@ -37,6 +37,7 @@ import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.vocabulary.RDF;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -838,6 +839,36 @@ public class TurtleFormatterTest {
       ).map( Arguments::of );
    }
 
+   @RepeatedTest( 10 )
+   void testInMemorySiblingBlankNodesAreOrderedByPrintableStructure() {
+      final TurtleFormatter formatter = new TurtleFormatter( FormattingStyle.DEFAULT );
+
+      final String result = formatter.apply( inMemorySiblingBlankNodeModel( true ) );
+      final String resultWithDifferentAllocationOrder = formatter.apply( inMemorySiblingBlankNodeModel( false ) );
+
+      assertThat( result ).isEqualTo( resultWithDifferentAllocationOrder );
+   }
+
+   @RepeatedTest( 10 )
+   void testInMemoryGeneratedBlankNodeIdsAreOrderedByPrintableStructure() {
+      final TurtleFormatter formatter = new TurtleFormatter( FormattingStyle.DEFAULT );
+
+      final String result = formatter.apply( inMemorySharedBlankNodeModel( true ) );
+      final String resultWithDifferentAllocationOrder = formatter.apply( inMemorySharedBlankNodeModel( false ) );
+
+      assertThat( result ).isEqualTo( resultWithDifferentAllocationOrder );
+   }
+
+   @RepeatedTest( 10 )
+   void testInMemoryBlankNodeCycleIsOrderedByPrintableStructure() {
+      final TurtleFormatter formatter = new TurtleFormatter( FormattingStyle.DEFAULT );
+
+      final String result = formatter.apply( inMemoryBlankNodeCycleModel( true ) );
+      final String resultWithDifferentAllocationOrder = formatter.apply( inMemoryBlankNodeCycleModel( false ) );
+
+      assertThat( result ).isEqualTo( resultWithDifferentAllocationOrder );
+   }
+
    @Test
    void testPreviouslyIdentifiedBlankNode() {
       final String content = """
@@ -1343,6 +1374,87 @@ public class TurtleFormatterTest {
       final TurtleFormatter formatter = new TurtleFormatter( style );
       final String result = formatter.applyToContent( content );
       assertThat( result.trim() ).isEqualTo( expected );
+   }
+
+   private Model inMemorySiblingBlankNodeModel( final boolean allocateSomethingElseFirst ) {
+      final String ex = "http://example.com/ns#";
+      final Model model = ModelFactory.createDefaultModel();
+      model.setNsPrefix( "ex", ex );
+
+      final Resource root = createResource( ex + "aThing" );
+      final Property has = createProperty( ex + "has" );
+      final Resource something = createResource( ex + "Something" );
+      final Resource somethingElse = createResource( ex + "SomethingElse" );
+
+      final Resource blankSomethingElse;
+      final Resource blankSomething;
+      if ( allocateSomethingElseFirst ) {
+         blankSomethingElse = model.createResource();
+         blankSomething = model.createResource();
+      } else {
+         blankSomething = model.createResource();
+         blankSomethingElse = model.createResource();
+      }
+      model.add( root, has, blankSomethingElse );
+      model.add( root, has, blankSomething );
+      model.add( blankSomethingElse, RDF.type, somethingElse );
+      model.add( blankSomething, RDF.type, something );
+      return model;
+   }
+
+   private Model inMemorySharedBlankNodeModel( final boolean allocateSomethingElseFirst ) {
+      final String ex = "http://example.com/ns#";
+      final Model model = inMemorySiblingBlankNodeModel( allocateSomethingElseFirst );
+      final Resource other = createResource( ex + "otherThing" );
+      final Property has = createProperty( ex + "has" );
+      final Resource blankSomethingElse = model.listStatements( null, RDF.type, createResource( ex + "SomethingElse" ) )
+            .nextStatement()
+            .getSubject();
+      final Resource blankSomething = model.listStatements( null, RDF.type, createResource( ex + "Something" ) )
+            .nextStatement()
+            .getSubject();
+      model.add( other, has, blankSomethingElse );
+      model.add( other, has, blankSomething );
+      return model;
+   }
+
+   private Model inMemoryBlankNodeCycleModel( final boolean allocateSecondBranchFirst ) {
+      final String ex = "http://example.com/ns#";
+      final Model model = ModelFactory.createDefaultModel();
+      model.setNsPrefix( "ex", ex );
+
+      final Resource root = createResource( ex + "aThing" );
+      final Property has = createProperty( ex + "has" );
+      final Property next = createProperty( ex + "next" );
+      final Property detail = createProperty( ex + "detail" );
+      final Resource firstType = createResource( ex + "First" );
+      final Resource secondType = createResource( ex + "Second" );
+
+      final Resource first;
+      final Resource second;
+      final Resource firstDetail;
+      final Resource secondDetail;
+      if ( allocateSecondBranchFirst ) {
+         second = model.createResource();
+         secondDetail = model.createResource();
+         first = model.createResource();
+         firstDetail = model.createResource();
+      } else {
+         first = model.createResource();
+         firstDetail = model.createResource();
+         second = model.createResource();
+         secondDetail = model.createResource();
+      }
+
+      model.add( root, has, first );
+      model.add( root, has, second );
+      model.add( first, next, second );
+      model.add( second, next, first );
+      model.add( first, detail, firstDetail );
+      model.add( second, detail, secondDetail );
+      model.add( firstDetail, RDF.type, firstType );
+      model.add( secondDetail, RDF.type, secondType );
+      return model;
    }
 
    private Model prefixModel() {


### PR DESCRIPTION
Blank node ordering had been stable if formatting a preexisting serialization, but not stable for an in-memory graph. This commit introduces partial ordering of blank nodes - those that are to be serialized as siblings. Their ordering is based on a key calculated from the triples they appear in. If needed for disambiguation, this is done recursively 3 times. After that, blank nodes compare as equal and will be ordered randomly. Bnode comparison keys are cached in a bounded map holding 100 x max 3 keys (one for each recursion layer).