### PR TITLE
Change JDK version to 21

### DIFF
--- a/cool-rdf-cli/src/main/java/cool/rdf/cli/CoolWrite.java
+++ b/cool-rdf-cli/src/main/java/cool/rdf/cli/CoolWrite.java
@@ -340,7 +340,7 @@ public class CoolWrite extends AbstractCommand implements Runnable {
    }
 
    private BiFunction<Resource, Integer, String> buildAnonymousNodeIdGenerator( final String pattern ) {
-      return ( _, integer ) -> pattern.replace( "0", "" + integer );
+      return ( res, integer ) -> pattern.replace( "0", "" + integer );
    }
 
    private static class NumberFormatConverter implements CommandLine.ITypeConverter<NumberFormat> {

--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,8 @@
     <properties>
         <!-- General settings -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <maven.surefire.skip>false</maven.surefire.skip>
         <maven.failsafe.skip>false</maven.failsafe.skip>
         <maven.shade.skip>false</maven.shade.skip>


### PR DESCRIPTION
Currently, Cool-RDF builds for JDK 25, But I am not convinced it's required. Users of the RDF formatter in the spotless plugin would be less disrupted if they did not need to update their JDK when updating. This PR just blindly tries if it would work Local build fails at diagram generation bc it does not find dot, but that should not be an issue here.